### PR TITLE
small refactoring stage2 assertions

### DIFF
--- a/Phrases/stage1/src/test/java/org/hyperskill/phrases/internals/PhrasesUnitTest.kt
+++ b/Phrases/stage1/src/test/java/org/hyperskill/phrases/internals/PhrasesUnitTest.kt
@@ -6,7 +6,7 @@ import android.content.Context
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.floatingactionbutton.FloatingActionButton
-import org.junit.Assert.assertEquals
+import org.junit.Assert.*
 import org.robolectric.Shadows
 import org.robolectric.shadows.ShadowNotificationManager
 
@@ -14,8 +14,8 @@ import org.robolectric.shadows.ShadowNotificationManager
 open class PhrasesUnitTest<T : Activity>(clazz: Class<T>): AbstractUnitTest<T>(clazz) {
 
     companion object {
-        const val CHANNEL_ID = "org.hyperskill.phrases"  // change as you like it
-        const val NOTIFICATION_ID = 393939               // change as you like it
+        const val CHANNEL_ID = "org.hyperskill.phrases"
+        const val NOTIFICATION_ID = 393939
     }
 
     protected val reminderTv: TextView by lazy {
@@ -42,5 +42,38 @@ open class PhrasesUnitTest<T : Activity>(clazz: Class<T>): AbstractUnitTest<T>(c
         )
     }
 
-    //  .... common recurring assertions, util functions, other views
+    protected fun RecyclerView.assertItemViewsExistOnItemWithIndex(index: Int = 0) {
+        this.assertSingleListItem(index) { itemViewSupplier ->
+            val itemView = itemViewSupplier()
+            itemView.findViewByString<TextView>("phraseTextView")
+            itemView.findViewByString<TextView>("phraseTextView")
+        }
+    }
+
+    protected fun RecyclerView.assertAmountItems(expectedAmount: Int) {
+        val actualInitialItems = this.adapter?.itemCount
+            ?: throw AssertionError("Could not find any RecyclerView.Adapter on recyclerView")
+        val messageInitialText = "The recyclerView doesn't have 3 or more items. Found $actualInitialItems items."
+        assertTrue(messageInitialText, (actualInitialItems >= expectedAmount))
+    }
+
+    protected fun RecyclerView.deleteLastItemAndAssertSizeDecreased() {
+        val adapter = this.adapter ?: throw AssertionError("Could not find any RecyclerView.Adapter on recyclerView")
+        val beforeDeleteSize = adapter.itemCount
+        val lastIndex = beforeDeleteSize - 1
+
+        assertSingleListItem(lastIndex) { itemViewSupplier ->
+            val itemView = itemViewSupplier()
+            itemView.findViewByString<TextView>("deleteTextView").clickAndRun()
+        }
+
+        val expectedSizeAfterDelete = beforeDeleteSize - 1
+        val actualSizeAfterDelete = adapter.itemCount
+
+        assertEquals(
+            "The recyclerView didn't remove item after clicking 'Delete'.",
+            expectedSizeAfterDelete,
+            actualSizeAfterDelete
+        )
+    }
 }

--- a/Phrases/stage2/src/test/java/org/hyperskill/phrases/Stage2UnitTest.kt
+++ b/Phrases/stage2/src/test/java/org/hyperskill/phrases/Stage2UnitTest.kt
@@ -1,34 +1,54 @@
 package org.hyperskill.phrases
 
 import org.hyperskill.phrases.internals.PhrasesUnitTest
+import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.junit.runners.MethodSorters
 import org.robolectric.RobolectricTestRunner
 
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @RunWith(RobolectricTestRunner::class)
 class Stage2UnitTest : PhrasesUnitTest<MainActivity>(MainActivity::class.java){
 
     @Test
-    fun checkReminderTextView() {
+    fun test00_checkReminderTextViewExists() {
         testActivity {
             reminderTv
         }
     }
 
     @Test
-    fun checkRecyclerView() {
+    fun test01_checkFloatingButtonExists() {
         testActivity {
-            recyclerView
-            recyclerViewItems()
-            recyclerViewCheckAmount()
-            recyclerViewClick()
+            floatingButton
         }
     }
 
     @Test
-    fun checkFloatingButton() {
+    fun test02_checkRecyclerViewExists() {
         testActivity {
-            floatingButton
+            recyclerView
+        }
+    }
+    @Test
+    fun test03_checkFirstListItemContainExpectedViews() {
+        testActivity {
+            recyclerView.assertItemViewsExistOnItemWithIndex(0)
+        }
+    }
+
+    @Test
+    fun test04_checkRecyclerViewHasAtLeastThreeItems() {
+        testActivity {
+            recyclerView.assertAmountItems(3)
+        }
+    }
+
+    @Test
+    fun test05_checkClickingDeleteDecreasesNumberOfItems() {
+        testActivity {
+            recyclerView.deleteLastItemAndAssertSizeDecreased()
         }
     }
 }

--- a/Phrases/stage2/src/test/java/org/hyperskill/phrases/internals/PhrasesUnitTest.kt
+++ b/Phrases/stage2/src/test/java/org/hyperskill/phrases/internals/PhrasesUnitTest.kt
@@ -14,8 +14,8 @@ import org.robolectric.shadows.ShadowNotificationManager
 open class PhrasesUnitTest<T : Activity>(clazz: Class<T>): AbstractUnitTest<T>(clazz) {
 
     companion object {
-        const val CHANNEL_ID = "org.hyperskill.phrases"  // change as you like it
-        const val NOTIFICATION_ID = 393939               // change as you like it
+        const val CHANNEL_ID = "org.hyperskill.phrases"
+        const val NOTIFICATION_ID = 393939
     }
 
     protected val reminderTv: TextView by lazy {
@@ -42,29 +42,38 @@ open class PhrasesUnitTest<T : Activity>(clazz: Class<T>): AbstractUnitTest<T>(c
         )
     }
 
-    protected fun recyclerViewItems(index: Int = 0) {
-        recyclerView.assertSingleListItem(index) { itemViewSupplier ->
+    protected fun RecyclerView.assertItemViewsExistOnItemWithIndex(index: Int = 0) {
+        this.assertSingleListItem(index) { itemViewSupplier ->
             val itemView = itemViewSupplier()
-            var phraseTV = itemView.findViewByString<TextView>("phraseTextView")
-            var deleteTV = itemView.findViewByString<TextView>("phraseTextView")
+            itemView.findViewByString<TextView>("phraseTextView")
+            itemView.findViewByString<TextView>("phraseTextView")
         }
     }
 
-    protected fun recyclerViewCheckAmount() {
-        val view = activity.findViewByString<RecyclerView>("recyclerView")
-        val expectedInitialItems = 3
-        val actualInitialItems = view.adapter!!.itemCount
+    protected fun RecyclerView.assertAmountItems(expectedAmount: Int) {
+        val actualInitialItems = this.adapter?.itemCount
+            ?: throw AssertionError("Could not find any RecyclerView.Adapter on recyclerView")
         val messageInitialText = "The recyclerView doesn't have 3 or more items. Found $actualInitialItems items."
-        assertTrue(messageInitialText, (actualInitialItems >= expectedInitialItems))
+        assertTrue(messageInitialText, (actualInitialItems >= expectedAmount))
     }
 
-    protected fun recyclerViewClick() {
-        val view: RecyclerView = activity.findViewByString("recyclerView")
-        val actualAmount = view.adapter!!.itemCount
-        val expectedAmount = actualAmount - 1
-        view.findViewByString<TextView>("deleteTextView").clickAndRun()
-        assertEquals("The recyclerView didn't remove item after clicking 'Delete'.", expectedAmount, view.adapter!!.itemCount)
-    }
+    protected fun RecyclerView.deleteLastItemAndAssertSizeDecreased() {
+        val adapter = this.adapter ?: throw AssertionError("Could not find any RecyclerView.Adapter on recyclerView")
+        val beforeDeleteSize = adapter.itemCount
+        val lastIndex = beforeDeleteSize - 1
 
-    //  .... common recurring assertions, util functions, other views
+        assertSingleListItem(lastIndex) { itemViewSupplier ->
+            val itemView = itemViewSupplier()
+            itemView.findViewByString<TextView>("deleteTextView").clickAndRun()
+        }
+
+        val expectedSizeAfterDelete = beforeDeleteSize - 1
+        val actualSizeAfterDelete = adapter.itemCount
+
+        assertEquals(
+            "The recyclerView didn't remove item after clicking 'Delete'.",
+            expectedSizeAfterDelete,
+            actualSizeAfterDelete
+        )
+    }
 }

--- a/Phrases/stage2/task-info.yaml
+++ b/Phrases/stage2/task-info.yaml
@@ -32,3 +32,5 @@ files:
   visible: true
 - name: src/main/java/org/hyperskill/phrases/Phrase.kt
   visible: true
+- name: src/main/res/layout/item_phrase.xml
+  visible: true


### PR DESCRIPTION
added more descriptive names to stage2 @Test
split recyclerView @Test on separate @Test for tested feature
added order to stage2 @tests
converted some functions to extension functions
handling possible null adapters by throwing assertion error
synchronized stage1 files with stage2 (files with same name across stages should have same content to make maintainer job easier not having to think why are files different, on purpose or by accident)

----

semantically tests remains the same, all tests remain passing against reference solution
  