### PR TITLE
removing explicit references to solution classes methods and fields

### DIFF
--- a/Phrases/stage4/src/main/java/org/hyperskill/phrases/data/room/AppDatabase.kt
+++ b/Phrases/stage4/src/main/java/org/hyperskill/phrases/data/room/AppDatabase.kt
@@ -26,6 +26,5 @@ abstract class AppDatabase : RoomDatabase() {
                 return INSTANCE!!
             }
         }
-
     }
 }

--- a/Phrases/stage4/src/test/java/org/hyperskill/phrases/internals/AbstractUnitTest.kt
+++ b/Phrases/stage4/src/test/java/org/hyperskill/phrases/internals/AbstractUnitTest.kt
@@ -2,6 +2,7 @@ package org.hyperskill.phrases.internals
 
 import android.app.Activity
 import android.app.AlertDialog
+import android.app.Dialog
 import android.content.Context
 import android.content.Intent
 import android.database.sqlite.SQLiteDatabase
@@ -233,7 +234,7 @@ abstract class AbstractUnitTest<T : Activity>(clazz: Class<T>) {
      */
     inner class TestDatabaseFactory(
         context: Context? = activity,
-        name: String? = "phrasesDatabase.db",
+        name: String? = "phrases.db",
         factory: SQLiteDatabase.CursorFactory? = null,
         version: Int = 1
     ) : SQLiteOpenHelper(context, name, factory, version) {
@@ -306,5 +307,24 @@ abstract class AbstractUnitTest<T : Activity>(clazz: Class<T>) {
         } else {
             throw IllegalStateException("size assertion was not effective")
         }
+    }
+
+    /**
+     * Use this method to find views.
+     *
+     * The view existence will be assert before being returned
+     */
+    inline fun <reified T> Dialog.findViewByString(idString: String): T {
+        val id = this.context.resources.getIdentifier(idString, "id", context.packageName)
+        val view: View? = this.findViewById(id)
+
+        val idNotFoundMessage = "View with id \"$idString\" was not found"
+        val wrongClassMessage = "View with id \"$idString\" is not from expected class. " +
+                "Expected ${T::class.java.simpleName} found ${view?.javaClass?.simpleName}"
+
+        assertNotNull(idNotFoundMessage, view)
+        assertTrue(wrongClassMessage, view is T)
+
+        return view as T
     }
 }


### PR DESCRIPTION
trying to solve issue #16

Still not entirely happy about this, but at least it won't throw build failures with incomplete solutions.

One thing that annoys me is that I'm having to set the INSTANCE property to null manually on tests through reflection on the method closeRoom(). That means that it has to be required on description the existence of a class org.hyperskill.phrases.data.room.AppDatabase and that it contains an INSTANCE property of type RoomDatabase.

I'm not sure how this code behaves with incorrect implementations of singletons, but for a correct implementation like the one in reference solution it works to close the database and set it to null.

Another thing that is annoying me  is that some tests methods are throwing a warning with SQLiteBusyException, but it does the job it is supposed to do anyway. The problem here is that users might get confused by that warning if that test is not passing.

