### PR TITLE
 rescheduling repeating alarms, #14 + sync files

### DIFF
--- a/Phrases/stage1/build.gradle
+++ b/Phrases/stage1/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion hs.android.compileSdkVersion
@@ -11,6 +12,11 @@ android {
         targetSdkVersion hs.android.targetSdkVersion
         versionCode 1
         versionName '1.0'
+        kapt {
+            arguments {
+                arg("room.schemaLocation", "$projectDir/schemas")
+            }
+        }
     }
 
     buildFeatures {
@@ -33,4 +39,14 @@ dependencies {
 
     def material = hs.android.lib.material
     implementation "com.google.android.material:material:$material"
+
+    def roomVersion = '2.3.0'
+    kapt "androidx.room:room-compiler:$roomVersion"
+    implementation "androidx.room:room-ktx:$roomVersion"
+    implementation "androidx.room:room-runtime:$roomVersion"
+
+    def lifecycleVersion = '2.2.0'
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
+
 }

--- a/Phrases/stage1/src/main/res/layout/activity_main.xml
+++ b/Phrases/stage1/src/main/res/layout/activity_main.xml
@@ -1,10 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
 
+    <TextView
+        android:id="@+id/reminderTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="No reminder set"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="409dp"
+        android:layout_height="681dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/reminderTextView" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/addButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:clickable="true"
+        android:contentDescription="Add"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:srcCompat="@android:drawable/ic_input_add" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Phrases/stage1/src/test/java/org/hyperskill/phrases/internals/AbstractUnitTest.kt
+++ b/Phrases/stage1/src/test/java/org/hyperskill/phrases/internals/AbstractUnitTest.kt
@@ -2,6 +2,7 @@ package org.hyperskill.phrases.internals
 
 import android.app.Activity
 import android.app.AlertDialog
+import android.app.Dialog
 import android.content.Context
 import android.content.Intent
 import android.database.sqlite.SQLiteDatabase
@@ -233,7 +234,7 @@ abstract class AbstractUnitTest<T : Activity>(clazz: Class<T>) {
      */
     inner class TestDatabaseFactory(
         context: Context? = activity,
-        name: String? = "phrasesDatabase.db",
+        name: String? = "phrases.db",
         factory: SQLiteDatabase.CursorFactory? = null,
         version: Int = 1
     ) : SQLiteOpenHelper(context, name, factory, version) {
@@ -306,5 +307,24 @@ abstract class AbstractUnitTest<T : Activity>(clazz: Class<T>) {
         } else {
             throw IllegalStateException("size assertion was not effective")
         }
+    }
+
+    /**
+     * Use this method to find views.
+     *
+     * The view existence will be assert before being returned
+     */
+    inline fun <reified T> Dialog.findViewByString(idString: String): T {
+        val id = this.context.resources.getIdentifier(idString, "id", context.packageName)
+        val view: View? = this.findViewById(id)
+
+        val idNotFoundMessage = "View with id \"$idString\" was not found"
+        val wrongClassMessage = "View with id \"$idString\" is not from expected class. " +
+                "Expected ${T::class.java.simpleName} found ${view?.javaClass?.simpleName}"
+
+        assertNotNull(idNotFoundMessage, view)
+        assertTrue(wrongClassMessage, view is T)
+
+        return view as T
     }
 }

--- a/Phrases/stage1/src/test/java/org/hyperskill/phrases/internals/PhrasesUnitTest.kt
+++ b/Phrases/stage1/src/test/java/org/hyperskill/phrases/internals/PhrasesUnitTest.kt
@@ -1,14 +1,25 @@
 package org.hyperskill.phrases.internals
 
-import android.app.Activity
-import android.app.NotificationManager
+import android.app.*
+import android.app.AlarmManager.OnAlarmListener
+import android.content.ContentValues
 import android.content.Context
+import android.database.sqlite.SQLiteException
+import android.os.Handler
+import android.os.SystemClock
 import android.widget.TextView
+import androidx.core.content.getSystemService
 import androidx.recyclerview.widget.RecyclerView
+import androidx.room.RoomDatabase
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import org.junit.Assert.*
 import org.robolectric.Shadows
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowAlarmManager
+import org.robolectric.shadows.ShadowAlarmManager.ScheduledAlarm
+import org.robolectric.shadows.ShadowDialog
 import org.robolectric.shadows.ShadowNotificationManager
+import java.util.concurrent.TimeUnit
 
 
 open class PhrasesUnitTest<T : Activity>(clazz: Class<T>): AbstractUnitTest<T>(clazz) {
@@ -16,6 +27,7 @@ open class PhrasesUnitTest<T : Activity>(clazz: Class<T>): AbstractUnitTest<T>(c
     companion object {
         const val CHANNEL_ID = "org.hyperskill.phrases"
         const val NOTIFICATION_ID = 393939
+        val fakePhrases = listOf("This is a test phrase", "This is another test phrase", "Yet another test phrase")
     }
 
     protected val reminderTv: TextView by lazy {
@@ -75,5 +87,165 @@ open class PhrasesUnitTest<T : Activity>(clazz: Class<T>): AbstractUnitTest<T>(c
             expectedSizeAfterDelete,
             actualSizeAfterDelete
         )
+    }
+
+    protected val notificationChannel: NotificationChannel by lazy {
+        val notificationChannel =
+            notificationManager.notificationChannels.mapNotNull {
+                it as NotificationChannel?
+            }.firstOrNull {
+                it.id == CHANNEL_ID
+            }
+
+        assertNotNull("Couldn't find notification channel with ID \"$CHANNEL_ID\"", notificationChannel)
+        notificationChannel!!
+    }
+
+    protected fun getLatestTimePickerDialog(notFoundMessage: String = "No TimePickerDialog was found"): android.app.TimePickerDialog {
+        return ShadowDialog.getShownDialogs().mapNotNull {
+            if(it is android.app.TimePickerDialog) it else null
+        }.lastOrNull() ?: throw AssertionError("No TimePickerDialog found")
+    }
+
+    protected fun android.app.TimePickerDialog.pickTime(hourOfDay: Int, minuteOfHour: Int, advanceClockMillis: Long = 500) {
+        val shadowTimePickerDialog = shadowOf(this)
+
+        this.updateTime(hourOfDay, minuteOfHour)
+        shadowTimePickerDialog.clickOn(android.R.id.button1) // ok button
+        shadowLooper.idleFor(advanceClockMillis, TimeUnit.MILLISECONDS)
+    }
+
+    fun supportForAlarmManager() {
+        val alarmManager = activity.getSystemService<AlarmManager>()
+        val shadowAlarmManager: ShadowAlarmManager = shadowOf(alarmManager)
+        val toTrigger = shadowAlarmManager.scheduledAlarms.filter {
+            it.triggerAtTime < SystemClock.currentGnssTimeClock().millis()
+        }
+        toTrigger.forEach { alarm ->
+            // trigger alarm
+            if(alarm.operation != null) {
+                val pendingIntent = shadowOf(alarm.operation)
+                if(alarm.triggerAtTime < SystemClock.currentGnssTimeClock().millis()) {
+                    alarm.operation.intentSender.sendIntent(
+                        pendingIntent.savedContext,
+                        pendingIntent.requestCode,
+                        pendingIntent.savedIntent,
+                        null,
+                        Handler(activity.mainLooper)
+                    )
+                    shadowLooper.idleFor(500, TimeUnit.MILLISECONDS)
+                }
+            } else if(alarm.onAlarmListener != null) {
+                if(alarm.triggerAtTime < SystemClock.currentGnssTimeClock().millis()) {
+                    alarm.onAlarmListener.onAlarm()
+                }
+            }
+
+            shadowAlarmManager.scheduledAlarms.remove(alarm) // remove triggered
+            if(alarm.interval > 0) {
+                // if repeating schedule next
+                val nextAlarm = alarm.copy(triggerAtTime = alarm.triggerAtTime + alarm.interval)
+                shadowAlarmManager.scheduledAlarms.add(nextAlarm)
+            }
+        }
+    }
+
+    private fun ScheduledAlarm.copy(
+        type: Int = this.type,
+        triggerAtTime: Long = this.triggerAtTime,
+        interval: Long = this.interval,
+        operation: PendingIntent? = this.operation,
+        showIntent: PendingIntent? = this.showIntent,
+        onAlarmListener: OnAlarmListener? = this.onAlarmListener,
+        handler: Handler? = this.handler
+    ): ScheduledAlarm {
+        val alarmConstructor = ScheduledAlarm::class.java.getDeclaredConstructor(
+            Int::class.java,
+            Long::class.java,
+            Long::class.java,
+            PendingIntent::class.java,
+            PendingIntent::class.java,
+            OnAlarmListener::class.java,
+            Handler::class.java
+        )
+        alarmConstructor.isAccessible = true
+        return alarmConstructor.newInstance(
+            type,
+            triggerAtTime,
+            interval,
+            operation,
+            showIntent,
+            onAlarmListener,
+            handler
+        )
+    }
+
+    protected fun addToDatabase(phrases: List<String>) {
+
+        TestDatabaseFactory().writableDatabase.use { database ->
+            database.execSQL("CREATE TABLE IF NOT EXISTS phrases (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, phrase TEXT NOT NULL)")
+            database.beginTransaction()
+            try {
+                phrases.forEach {
+                    ContentValues().apply {
+                        put("phrase", it)
+                        database.insert("phrases", null, this)
+                    }
+                }
+                database.setTransactionSuccessful()
+            } catch (ex: SQLiteException) {
+                ex.printStackTrace()
+                fail(ex.stackTraceToString())
+            } catch (ex: IllegalStateException) {
+                ex.printStackTrace()
+                fail(ex.stackTraceToString())
+            } finally {
+                database.endTransaction()
+            }
+        }
+    }
+
+    protected fun readAllFromDatabase(): List<String> {
+
+        val phrasesFromDb = mutableListOf<String>()
+
+        TestDatabaseFactory().readableDatabase.use { database ->
+            database.query("phrases", null,
+                null, null, null, null, null).use { cursor ->
+
+                val phraseColumnIndex = cursor.getColumnIndex("phrase")
+                assertTrue("phrase column was not found", phraseColumnIndex >= 0)
+
+                while(cursor.moveToNext()) {
+                    val phrase = cursor.getString(phraseColumnIndex)
+                    phrasesFromDb.add(phrase)
+                }
+            }
+        }
+
+        return phrasesFromDb
+    }
+
+    fun closeRoom() {
+        val clazzName = "org.hyperskill.phrases.data.room.AppDatabase"
+        val clazz: Class<*> = try {
+            Class.forName(clazzName)
+        } catch (e: ClassNotFoundException ) {
+            throw AssertionError("Could not find on solution a class $clazzName")
+        }
+
+        val instanceField = try {
+            clazz.getDeclaredField("INSTANCE")
+        } catch (e: NoSuchFieldException) {
+            throw AssertionError("Could not find on $clazzName a field named INSTANCE")
+        }
+
+        instanceField.isAccessible = true
+        val instanceAsAny: Any = instanceField.get(clazz) ?: return
+
+        assertTrue("AppDatabase.INSTANCE should be a RoomDatabase", instanceAsAny is RoomDatabase)
+        val roomInstance = instanceAsAny as RoomDatabase
+        roomInstance.close()
+        instanceField.set(null, null)
     }
 }

--- a/Phrases/stage2/src/test/java/org/hyperskill/phrases/internals/AbstractUnitTest.kt
+++ b/Phrases/stage2/src/test/java/org/hyperskill/phrases/internals/AbstractUnitTest.kt
@@ -2,6 +2,7 @@ package org.hyperskill.phrases.internals
 
 import android.app.Activity
 import android.app.AlertDialog
+import android.app.Dialog
 import android.content.Context
 import android.content.Intent
 import android.database.sqlite.SQLiteDatabase
@@ -233,7 +234,7 @@ abstract class AbstractUnitTest<T : Activity>(clazz: Class<T>) {
      */
     inner class TestDatabaseFactory(
         context: Context? = activity,
-        name: String? = "phrasesDatabase.db",
+        name: String? = "phrases.db",
         factory: SQLiteDatabase.CursorFactory? = null,
         version: Int = 1
     ) : SQLiteOpenHelper(context, name, factory, version) {
@@ -306,5 +307,24 @@ abstract class AbstractUnitTest<T : Activity>(clazz: Class<T>) {
         } else {
             throw IllegalStateException("size assertion was not effective")
         }
+    }
+
+    /**
+     * Use this method to find views.
+     *
+     * The view existence will be assert before being returned
+     */
+    inline fun <reified T> Dialog.findViewByString(idString: String): T {
+        val id = this.context.resources.getIdentifier(idString, "id", context.packageName)
+        val view: View? = this.findViewById(id)
+
+        val idNotFoundMessage = "View with id \"$idString\" was not found"
+        val wrongClassMessage = "View with id \"$idString\" is not from expected class. " +
+                "Expected ${T::class.java.simpleName} found ${view?.javaClass?.simpleName}"
+
+        assertNotNull(idNotFoundMessage, view)
+        assertTrue(wrongClassMessage, view is T)
+
+        return view as T
     }
 }

--- a/Phrases/stage2/src/test/java/org/hyperskill/phrases/internals/PhrasesUnitTest.kt
+++ b/Phrases/stage2/src/test/java/org/hyperskill/phrases/internals/PhrasesUnitTest.kt
@@ -1,14 +1,25 @@
 package org.hyperskill.phrases.internals
 
-import android.app.Activity
-import android.app.NotificationManager
+import android.app.*
+import android.app.AlarmManager.OnAlarmListener
+import android.content.ContentValues
 import android.content.Context
+import android.database.sqlite.SQLiteException
+import android.os.Handler
+import android.os.SystemClock
 import android.widget.TextView
+import androidx.core.content.getSystemService
 import androidx.recyclerview.widget.RecyclerView
+import androidx.room.RoomDatabase
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import org.junit.Assert.*
 import org.robolectric.Shadows
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowAlarmManager
+import org.robolectric.shadows.ShadowAlarmManager.ScheduledAlarm
+import org.robolectric.shadows.ShadowDialog
 import org.robolectric.shadows.ShadowNotificationManager
+import java.util.concurrent.TimeUnit
 
 
 open class PhrasesUnitTest<T : Activity>(clazz: Class<T>): AbstractUnitTest<T>(clazz) {
@@ -16,6 +27,7 @@ open class PhrasesUnitTest<T : Activity>(clazz: Class<T>): AbstractUnitTest<T>(c
     companion object {
         const val CHANNEL_ID = "org.hyperskill.phrases"
         const val NOTIFICATION_ID = 393939
+        val fakePhrases = listOf("This is a test phrase", "This is another test phrase", "Yet another test phrase")
     }
 
     protected val reminderTv: TextView by lazy {
@@ -75,5 +87,165 @@ open class PhrasesUnitTest<T : Activity>(clazz: Class<T>): AbstractUnitTest<T>(c
             expectedSizeAfterDelete,
             actualSizeAfterDelete
         )
+    }
+
+    protected val notificationChannel: NotificationChannel by lazy {
+        val notificationChannel =
+            notificationManager.notificationChannels.mapNotNull {
+                it as NotificationChannel?
+            }.firstOrNull {
+                it.id == CHANNEL_ID
+            }
+
+        assertNotNull("Couldn't find notification channel with ID \"$CHANNEL_ID\"", notificationChannel)
+        notificationChannel!!
+    }
+
+    protected fun getLatestTimePickerDialog(notFoundMessage: String = "No TimePickerDialog was found"): android.app.TimePickerDialog {
+        return ShadowDialog.getShownDialogs().mapNotNull {
+            if(it is android.app.TimePickerDialog) it else null
+        }.lastOrNull() ?: throw AssertionError("No TimePickerDialog found")
+    }
+
+    protected fun android.app.TimePickerDialog.pickTime(hourOfDay: Int, minuteOfHour: Int, advanceClockMillis: Long = 500) {
+        val shadowTimePickerDialog = shadowOf(this)
+
+        this.updateTime(hourOfDay, minuteOfHour)
+        shadowTimePickerDialog.clickOn(android.R.id.button1) // ok button
+        shadowLooper.idleFor(advanceClockMillis, TimeUnit.MILLISECONDS)
+    }
+
+    fun supportForAlarmManager() {
+        val alarmManager = activity.getSystemService<AlarmManager>()
+        val shadowAlarmManager: ShadowAlarmManager = shadowOf(alarmManager)
+        val toTrigger = shadowAlarmManager.scheduledAlarms.filter {
+            it.triggerAtTime < SystemClock.currentGnssTimeClock().millis()
+        }
+        toTrigger.forEach { alarm ->
+            // trigger alarm
+            if(alarm.operation != null) {
+                val pendingIntent = shadowOf(alarm.operation)
+                if(alarm.triggerAtTime < SystemClock.currentGnssTimeClock().millis()) {
+                    alarm.operation.intentSender.sendIntent(
+                        pendingIntent.savedContext,
+                        pendingIntent.requestCode,
+                        pendingIntent.savedIntent,
+                        null,
+                        Handler(activity.mainLooper)
+                    )
+                    shadowLooper.idleFor(500, TimeUnit.MILLISECONDS)
+                }
+            } else if(alarm.onAlarmListener != null) {
+                if(alarm.triggerAtTime < SystemClock.currentGnssTimeClock().millis()) {
+                    alarm.onAlarmListener.onAlarm()
+                }
+            }
+
+            shadowAlarmManager.scheduledAlarms.remove(alarm) // remove triggered
+            if(alarm.interval > 0) {
+                // if repeating schedule next
+                val nextAlarm = alarm.copy(triggerAtTime = alarm.triggerAtTime + alarm.interval)
+                shadowAlarmManager.scheduledAlarms.add(nextAlarm)
+            }
+        }
+    }
+
+    private fun ScheduledAlarm.copy(
+        type: Int = this.type,
+        triggerAtTime: Long = this.triggerAtTime,
+        interval: Long = this.interval,
+        operation: PendingIntent? = this.operation,
+        showIntent: PendingIntent? = this.showIntent,
+        onAlarmListener: OnAlarmListener? = this.onAlarmListener,
+        handler: Handler? = this.handler
+    ): ScheduledAlarm {
+        val alarmConstructor = ScheduledAlarm::class.java.getDeclaredConstructor(
+            Int::class.java,
+            Long::class.java,
+            Long::class.java,
+            PendingIntent::class.java,
+            PendingIntent::class.java,
+            OnAlarmListener::class.java,
+            Handler::class.java
+        )
+        alarmConstructor.isAccessible = true
+        return alarmConstructor.newInstance(
+            type,
+            triggerAtTime,
+            interval,
+            operation,
+            showIntent,
+            onAlarmListener,
+            handler
+        )
+    }
+
+    protected fun addToDatabase(phrases: List<String>) {
+
+        TestDatabaseFactory().writableDatabase.use { database ->
+            database.execSQL("CREATE TABLE IF NOT EXISTS phrases (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, phrase TEXT NOT NULL)")
+            database.beginTransaction()
+            try {
+                phrases.forEach {
+                    ContentValues().apply {
+                        put("phrase", it)
+                        database.insert("phrases", null, this)
+                    }
+                }
+                database.setTransactionSuccessful()
+            } catch (ex: SQLiteException) {
+                ex.printStackTrace()
+                fail(ex.stackTraceToString())
+            } catch (ex: IllegalStateException) {
+                ex.printStackTrace()
+                fail(ex.stackTraceToString())
+            } finally {
+                database.endTransaction()
+            }
+        }
+    }
+
+    protected fun readAllFromDatabase(): List<String> {
+
+        val phrasesFromDb = mutableListOf<String>()
+
+        TestDatabaseFactory().readableDatabase.use { database ->
+            database.query("phrases", null,
+                null, null, null, null, null).use { cursor ->
+
+                val phraseColumnIndex = cursor.getColumnIndex("phrase")
+                assertTrue("phrase column was not found", phraseColumnIndex >= 0)
+
+                while(cursor.moveToNext()) {
+                    val phrase = cursor.getString(phraseColumnIndex)
+                    phrasesFromDb.add(phrase)
+                }
+            }
+        }
+
+        return phrasesFromDb
+    }
+
+    fun closeRoom() {
+        val clazzName = "org.hyperskill.phrases.data.room.AppDatabase"
+        val clazz: Class<*> = try {
+            Class.forName(clazzName)
+        } catch (e: ClassNotFoundException ) {
+            throw AssertionError("Could not find on solution a class $clazzName")
+        }
+
+        val instanceField = try {
+            clazz.getDeclaredField("INSTANCE")
+        } catch (e: NoSuchFieldException) {
+            throw AssertionError("Could not find on $clazzName a field named INSTANCE")
+        }
+
+        instanceField.isAccessible = true
+        val instanceAsAny: Any = instanceField.get(clazz) ?: return
+
+        assertTrue("AppDatabase.INSTANCE should be a RoomDatabase", instanceAsAny is RoomDatabase)
+        val roomInstance = instanceAsAny as RoomDatabase
+        roomInstance.close()
+        instanceField.set(null, null)
     }
 }

--- a/Phrases/stage3/src/test/java/org/hyperskill/phrases/internals/AbstractUnitTest.kt
+++ b/Phrases/stage3/src/test/java/org/hyperskill/phrases/internals/AbstractUnitTest.kt
@@ -2,6 +2,7 @@ package org.hyperskill.phrases.internals
 
 import android.app.Activity
 import android.app.AlertDialog
+import android.app.Dialog
 import android.content.Context
 import android.content.Intent
 import android.database.sqlite.SQLiteDatabase
@@ -233,7 +234,7 @@ abstract class AbstractUnitTest<T : Activity>(clazz: Class<T>) {
      */
     inner class TestDatabaseFactory(
         context: Context? = activity,
-        name: String? = "phrasesDatabase.db",
+        name: String? = "phrases.db",
         factory: SQLiteDatabase.CursorFactory? = null,
         version: Int = 1
     ) : SQLiteOpenHelper(context, name, factory, version) {
@@ -306,5 +307,24 @@ abstract class AbstractUnitTest<T : Activity>(clazz: Class<T>) {
         } else {
             throw IllegalStateException("size assertion was not effective")
         }
+    }
+
+    /**
+     * Use this method to find views.
+     *
+     * The view existence will be assert before being returned
+     */
+    inline fun <reified T> Dialog.findViewByString(idString: String): T {
+        val id = this.context.resources.getIdentifier(idString, "id", context.packageName)
+        val view: View? = this.findViewById(id)
+
+        val idNotFoundMessage = "View with id \"$idString\" was not found"
+        val wrongClassMessage = "View with id \"$idString\" is not from expected class. " +
+                "Expected ${T::class.java.simpleName} found ${view?.javaClass?.simpleName}"
+
+        assertNotNull(idNotFoundMessage, view)
+        assertTrue(wrongClassMessage, view is T)
+
+        return view as T
     }
 }

--- a/Phrases/stage3/src/test/java/org/hyperskill/phrases/internals/PhrasesUnitTest.kt
+++ b/Phrases/stage3/src/test/java/org/hyperskill/phrases/internals/PhrasesUnitTest.kt
@@ -1,21 +1,22 @@
 package org.hyperskill.phrases.internals
 
-import android.app.Activity
-import android.app.AlarmManager
-import android.app.NotificationChannel
-import android.app.NotificationManager
+import android.app.*
+import android.app.AlarmManager.OnAlarmListener
+import android.content.ContentValues
 import android.content.Context
+import android.database.sqlite.SQLiteException
 import android.os.Handler
 import android.os.SystemClock
 import android.widget.TextView
 import androidx.core.content.getSystemService
 import androidx.recyclerview.widget.RecyclerView
+import androidx.room.RoomDatabase
 import com.google.android.material.floatingactionbutton.FloatingActionButton
-import org.hyperskill.phrases.TimePickerDialog
 import org.junit.Assert.*
 import org.robolectric.Shadows
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowAlarmManager
+import org.robolectric.shadows.ShadowAlarmManager.ScheduledAlarm
 import org.robolectric.shadows.ShadowDialog
 import org.robolectric.shadows.ShadowNotificationManager
 import java.util.concurrent.TimeUnit
@@ -26,6 +27,7 @@ open class PhrasesUnitTest<T : Activity>(clazz: Class<T>): AbstractUnitTest<T>(c
     companion object {
         const val CHANNEL_ID = "org.hyperskill.phrases"
         const val NOTIFICATION_ID = 393939
+        val fakePhrases = listOf("This is a test phrase", "This is another test phrase", "Yet another test phrase")
     }
 
     protected val reminderTv: TextView by lazy {
@@ -119,11 +121,12 @@ open class PhrasesUnitTest<T : Activity>(clazz: Class<T>): AbstractUnitTest<T>(c
         val toTrigger = shadowAlarmManager.scheduledAlarms.filter {
             it.triggerAtTime < SystemClock.currentGnssTimeClock().millis()
         }
-        toTrigger.forEach {
-            if(it.operation != null) {
-                val pendingIntent = Shadows.shadowOf(it.operation)
-                if(it.triggerAtTime < SystemClock.currentGnssTimeClock().millis()) {
-                    it.operation.intentSender.sendIntent(
+        toTrigger.forEach { alarm ->
+            // trigger alarm
+            if(alarm.operation != null) {
+                val pendingIntent = shadowOf(alarm.operation)
+                if(alarm.triggerAtTime < SystemClock.currentGnssTimeClock().millis()) {
+                    alarm.operation.intentSender.sendIntent(
                         pendingIntent.savedContext,
                         pendingIntent.requestCode,
                         pendingIntent.savedIntent,
@@ -132,12 +135,117 @@ open class PhrasesUnitTest<T : Activity>(clazz: Class<T>): AbstractUnitTest<T>(c
                     )
                     shadowLooper.idleFor(500, TimeUnit.MILLISECONDS)
                 }
-            } else if(it.onAlarmListener != null) {
-                if(it.triggerAtTime < SystemClock.currentGnssTimeClock().millis()) {
-                    it.onAlarmListener.onAlarm()
+            } else if(alarm.onAlarmListener != null) {
+                if(alarm.triggerAtTime < SystemClock.currentGnssTimeClock().millis()) {
+                    alarm.onAlarmListener.onAlarm()
                 }
             }
-            shadowAlarmManager.scheduledAlarms.remove(it)
+
+            shadowAlarmManager.scheduledAlarms.remove(alarm) // remove triggered
+            if(alarm.interval > 0) {
+                // if repeating schedule next
+                val nextAlarm = alarm.copy(triggerAtTime = alarm.triggerAtTime + alarm.interval)
+                shadowAlarmManager.scheduledAlarms.add(nextAlarm)
+            }
         }
+    }
+
+    private fun ScheduledAlarm.copy(
+        type: Int = this.type,
+        triggerAtTime: Long = this.triggerAtTime,
+        interval: Long = this.interval,
+        operation: PendingIntent? = this.operation,
+        showIntent: PendingIntent? = this.showIntent,
+        onAlarmListener: OnAlarmListener? = this.onAlarmListener,
+        handler: Handler? = this.handler
+    ): ScheduledAlarm {
+        val alarmConstructor = ScheduledAlarm::class.java.getDeclaredConstructor(
+            Int::class.java,
+            Long::class.java,
+            Long::class.java,
+            PendingIntent::class.java,
+            PendingIntent::class.java,
+            OnAlarmListener::class.java,
+            Handler::class.java
+        )
+        alarmConstructor.isAccessible = true
+        return alarmConstructor.newInstance(
+            type,
+            triggerAtTime,
+            interval,
+            operation,
+            showIntent,
+            onAlarmListener,
+            handler
+        )
+    }
+
+    protected fun addToDatabase(phrases: List<String>) {
+
+        TestDatabaseFactory().writableDatabase.use { database ->
+            database.execSQL("CREATE TABLE IF NOT EXISTS phrases (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, phrase TEXT NOT NULL)")
+            database.beginTransaction()
+            try {
+                phrases.forEach {
+                    ContentValues().apply {
+                        put("phrase", it)
+                        database.insert("phrases", null, this)
+                    }
+                }
+                database.setTransactionSuccessful()
+            } catch (ex: SQLiteException) {
+                ex.printStackTrace()
+                fail(ex.stackTraceToString())
+            } catch (ex: IllegalStateException) {
+                ex.printStackTrace()
+                fail(ex.stackTraceToString())
+            } finally {
+                database.endTransaction()
+            }
+        }
+    }
+
+    protected fun readAllFromDatabase(): List<String> {
+
+        val phrasesFromDb = mutableListOf<String>()
+
+        TestDatabaseFactory().readableDatabase.use { database ->
+            database.query("phrases", null,
+                null, null, null, null, null).use { cursor ->
+
+                val phraseColumnIndex = cursor.getColumnIndex("phrase")
+                assertTrue("phrase column was not found", phraseColumnIndex >= 0)
+
+                while(cursor.moveToNext()) {
+                    val phrase = cursor.getString(phraseColumnIndex)
+                    phrasesFromDb.add(phrase)
+                }
+            }
+        }
+
+        return phrasesFromDb
+    }
+
+    fun closeRoom() {
+        val clazzName = "org.hyperskill.phrases.data.room.AppDatabase"
+        val clazz: Class<*> = try {
+            Class.forName(clazzName)
+        } catch (e: ClassNotFoundException ) {
+            throw AssertionError("Could not find on solution a class $clazzName")
+        }
+
+        val instanceField = try {
+            clazz.getDeclaredField("INSTANCE")
+        } catch (e: NoSuchFieldException) {
+            throw AssertionError("Could not find on $clazzName a field named INSTANCE")
+        }
+
+        instanceField.isAccessible = true
+        val instanceAsAny: Any = instanceField.get(clazz) ?: return
+
+        assertTrue("AppDatabase.INSTANCE should be a RoomDatabase", instanceAsAny is RoomDatabase)
+        val roomInstance = instanceAsAny as RoomDatabase
+        roomInstance.close()
+        instanceField.set(null, null)
     }
 }


### PR DESCRIPTION
- fixing issue #14
    - if an alarm has interval then a new alarm with updated trigger is added after removing triggered alarm
- sync test files with same name
    - test files with same name should have same code to make maintaining easier for future fixers
- add all project dependencies to first stage build.gradle
    - when the project is published only the first stage will contain a build.gradle
    - remaining stages will receive build.gradle from previous stage when user passes from one stage to another
- added first stage solution
    - just to check if all tests are passing
 